### PR TITLE
Add docker-compose.yml file and instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+./pgdata/
+./files/
+CONTRIBUTING
+.git/
+./demo.py
+./docker-compose.yml
+./docs/
+./example-data
+./LICENSE
+./MANIFEST.in
+./README.md
+./server_schemas
+./setup.py
+./tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
 .*
 !.gitignore
 !.gitlab-ci.yml
+!.dockerignore
 _*
 !__init__.py
 !__main__.py
 ldapaccount.py
 docs/static/img/generated
 version.txt
+pgdata/
+files/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,22 @@ If you would like to set up a development version of SampleDB instead, please se
 
 If you do not have Docker installed yet, please [install Docker](https://docs.docker.com/engine/install/).
 
+### Using docker-compose
+
+First, get the docker-compose.yml configuration file. You can git clone this repo or just get the file:
+
+```bash
+curl https://raw.githubusercontent.com/sciapp/sampledb/develop/docker-compose.yml --output docker-compose.yml
+```
+
+Then simply bring everything up with:
+
+```bash
+docker-compose up -d
+```
+
+### Using docker commands
+
 First, start your database container:
 
 ```bash
@@ -48,6 +64,8 @@ docker run \
     -p 8000:8000 \
     sciapp/sampledb:0.14.0
 ```
+
+### Once it's started
 
 This will start a minimal SampleDB installation at `http://localhost:8000` and allow you to sign in with the username `admin` and the password `password` (which you should change immediately after signing in).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+# sampledb docker-compose configuration file
+# use : "docker-compose up -d" to start containers
+# https://github.com/sciapp/sampledb
+# Note: you will need to edit some values below to run it in production!
+version: '3'
+
+services:
+  web:
+    image: sciapp/sampledb:0.14.0
+    restart: always
+    container_name: sampledb
+    environment:
+        - SAMPLEDB_CONTACT_EMAIL=sampledb@example.com
+        - SAMPLEDB_MAILSERVER=mail.example.com
+        - SAMPLEDB_MAIL_SENDER=sampledb@example.com
+        - SAMPLEDB_ADMIN_PASSWORD=password
+        - SAMPLEDB_SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://postgres:password@sampledb-postgres:5432/postgres
+        - SAMPLEDB_FILE_STORAGE_PATH=/home/sampledb/files/
+    ports:
+        # if you want sampledb to run on a different port, change the first number
+        # host:container
+        - '8000:8000'
+    volumes:
+        # this is where you will keep the uploaded files persistently
+        # host:container
+        - ./files:/home/sampledb/files
+    networks:
+      - sampledb-net
+
+  # the postgres database image
+  db:
+    image: postgres:12
+    restart: always
+    container_name: sampledb-postgres
+    environment:
+        - POSTGRES_PASSWORD=password
+        - PGDATA=/var/lib/postgresql/data/pgdata
+    volumes:
+        # this is where you will keep the database persistently
+        # host:container
+        - ./pgdata:/var/lib/postgresql/data/pgdata
+    networks:
+      - sampledb-net
+
+# the internal sampledb network
+networks:
+  sampledb-net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     container_name: sampledb
     environment:
         - SAMPLEDB_CONTACT_EMAIL=sampledb@example.com
-        - SAMPLEDB_MAILSERVER=mail.example.com
+        - SAMPLEDB_MAIL_SERVER=mail.example.com
         - SAMPLEDB_MAIL_SENDER=sampledb@example.com
         - SAMPLEDB_ADMIN_PASSWORD=password
         - SAMPLEDB_SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://postgres:password@sampledb-postgres:5432/postgres


### PR DESCRIPTION
I think it's much easier to have a docker-compose.yml file that is easily editable instead of multi-line docker run commands. So I added one with the instructions in the README.
