### PR TITLE
Validation preprocessor

### DIFF
--- a/sampledb/config.py
+++ b/sampledb/config.py
@@ -44,7 +44,12 @@ def use_environment_configuration(env_prefix):
     """
     config = load_environment_configuration(env_prefix)
     for name, value in config.items():
-        globals()[name] = value
+        if value.lower() == "true":
+            globals()[name] = True
+        elif value.lower() == "false":
+            globals()[name] = False
+        else:
+            globals()[name] = value
 
 
 def check_config(
@@ -389,6 +394,9 @@ ONLY_ADMINS_CAN_MANAGE_LOCATIONS = False
 ONLY_ADMINS_CAN_DELETE_GROUPS = False
 
 LOAD_OBJECTS_IN_BACKGROUND = False
+
+# as default disable partial object updates (only changing one value at a time and keep the rest untouched)
+ALLOW_PARTIAL_OBJECT_UPDATES = False
 
 # environment variables override these values
 use_environment_configuration(env_prefix='SAMPLEDB_')

--- a/sampledb/logic/datatypes.py
+++ b/sampledb/logic/datatypes.py
@@ -154,6 +154,9 @@ class Quantity(object):
             'magnitude_in_base_units': {
                 'type': 'number'
             },
+            'magnitude': {
+                'type': 'number'
+            },
             'units': {
                 'anyOf': [
                     {'type': 'null'},
@@ -165,7 +168,7 @@ class Quantity(object):
         'additionalProperties': False
     }
 
-    def __init__(self, magnitude, units):
+    def __init__(self, magnitude, units, already_in_base_units = False):
         self.magnitude = float(magnitude)
         if units is None:
             self.units = None
@@ -181,7 +184,12 @@ class Quantity(object):
                     self.pint_units = ureg.Unit(self.units)
                 except (pint.errors.UndefinedUnitError, AttributeError):
                     raise ValueError("Invalid units '{}'".format(self.units))
-            self.magnitude_in_base_units = ureg.Quantity(self.magnitude, self.pint_units).to_base_units().magnitude
+            if already_in_base_units is False:
+                self.magnitude_in_base_units = ureg.Quantity(self.magnitude, self.pint_units).to_base_units().magnitude 
+            else:
+                self.magnitude_in_base_units = self.magnitude
+                pint_base_units = ureg.Quantity(1, self.pint_units).to_base_units().units
+                self.magnitude = ureg.Quantity(self.magnitude_in_base_units, pint_base_units).to(self.pint_units).magnitude
         self.dimensionality = self.pint_units.dimensionality
 
     def __repr__(self):
@@ -192,6 +200,7 @@ class Quantity(object):
 
     def to_json(self):
         return {
+            'magnitude': self.magnitude,
             'magnitude_in_base_units': self.magnitude_in_base_units,
             'units': self.units,
             'dimensionality': str(self.dimensionality)

--- a/sampledb/logic/schemas/validation_preprocessor.py
+++ b/sampledb/logic/schemas/validation_preprocessor.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Nov 26 15:32:24 2020
+
+@author: b.mayer
+
+This validation preprocessor extends submitted update data silently if possible.
+So that partial updates or redundant field  definitions like pint's dimensionality do not have to be submitted everytime. 
+"""
+
+import flask
+
+from ...logic import objects, datatypes, errors, units
+from .utils import units_are_valid, get_dimensionality_for_units
+
+def _validation_preprocessor_object(instance: dict, schema: dict, object_id: int) -> None:
+    """
+    If the given object is the root object to be updated 
+    (not a data type "object" reference to another object)
+    then this function extends the data in the instance dictionary 
+    in case there are any schema properties missing with the data 
+    from the objects current version. This allows for partial updates 
+    via the API while keeping the rest of the data untouched.
+    
+    This function can be toggled on via the configuration parameter SAMPLEDB_ALLOW_PARTIAL_OBJECT_UPDATES
+
+    :param instance: the sample object
+    :param schema: the valid sampledb object schema
+    """
+    if flask.current_app.config['ALLOW_PARTIAL_OBJECT_UPDATES'] == False:
+        return
+    
+    if not isinstance(instance, dict) or object_id == None:
+        return
+        
+    current_object = objects.get_object(object_id)
+    if current_object is None:
+        return 
+        
+    for key in current_object.data:
+        if key not in instance:
+            instance[key] = current_object.data[key]
+
+    
+def _validation_preprocessor_quantity(instance: dict, schema: dict) -> None:
+    """
+    Extends the json to update a quantity object by the unit from the schema, 
+    the dimensionality and either the magnitude or the magnitute_in_base_units parameter
+    
+    :param instance: the sample object
+    :param schema: the valid sampledb object schema
+    """
+    
+    if not isinstance(instance, dict):
+        return instance
+    if '_type' not in instance:
+        return instance #maybe set to schema type?
+    if 'units' not in instance:
+        instance['units'] = schema['units']
+        
+    magnitude_datatype = None
+    magnitude_base_datatype = None
+    if 'magnitude' in instance:
+        magnitude_datatype = datatypes.Quantity(instance['magnitude'], units=instance['units'], already_in_base_units=False)
+    if 'magnitude_in_base_units' in instance:
+        magnitude_base_datatype = datatypes.Quantity(instance['magnitude_in_base_units'], units=instance['units'], already_in_base_units=True)
+    
+    if magnitude_datatype is not None and magnitude_base_datatype is not None and magnitude_datatype != magnitude_base_datatype:
+        raise errors.ValidationError('magnitude and magnitude_in_base_units do not match, either set only one or make sure both match', None)
+    elif magnitude_datatype is None:
+        magnitude_datatype = magnitude_base_datatype
+        
+    instance.update(magnitude_datatype.to_json())
+        

--- a/sampledb/logic/schemas/validation_preprocessor.py
+++ b/sampledb/logic/schemas/validation_preprocessor.py
@@ -27,7 +27,7 @@ def _validation_preprocessor_object(instance: dict, schema: dict, object_id: int
     :param instance: the sample object
     :param schema: the valid sampledb object schema
     """
-    if flask.current_app.config['ALLOW_PARTIAL_OBJECT_UPDATES'] == False:
+    if flask.current_app.config['ALLOW_PARTIAL_OBJECT_UPDATES'] is False:
         return
     
     if not isinstance(instance, dict) or object_id == None:

--- a/sampledb/models/versioned_json_object_tables.py
+++ b/sampledb/models/versioned_json_object_tables.py
@@ -190,7 +190,7 @@ class VersionedJSONSerializableObjectTables(object):
         if self._schema_validator:
             self._schema_validator(schema)
         if self._data_validator:
-            self._data_validator(data, schema)
+            self._data_validator(data, schema, object_id=object_id)
         with connection.begin() as transaction:
             # Copy current version to previous versions
             if connection.execute(


### PR DESCRIPTION
This pull request is for a preliminary review. The code is tested, but i have not yet created pytest test cases or updated the docs. 

**Features:**
* Allowing partial object updates if the new config variable ALLOW_PARTIAL_OBJECT_UPDATES is true
* Automatically assume that the unit of a Quantity matches the scheme unit if not given
* Accept either magnitude or magnitude_in_base_units or both for a Quantity object. If both are given they have to match each other, otherwise automatically calculate the other one
* Return both magnitude and magnitude_in_base_units

**Additional fixes:**
* Boolean config variables from the env were represented as a string despite the default value being set as an actual boolean
* The quantity validation function created a new Quantity object based on the magnitude_in_base_units with the non-base unit despite the old version of the constructor only expecting an already converted magnitude