### PR TITLE
Disable browser suggestions for TOTP code input fields

### DIFF
--- a/sampledb/frontend/templates/two_factor_authentication/confirm_totp.html
+++ b/sampledb/frontend/templates/two_factor_authentication/confirm_totp.html
@@ -17,7 +17,7 @@
       {% endif %}
     </p>
     <div class="form-group {% if confirm_form.is_submitted() %}has-error{% endif %}">
-      <input type="text" placeholder="{{ _('Verification Code') }}" name="{{ confirm_form.code.name }}" class="form-control" style="width: 204px; display:inline-block;"/>
+      <input type="text" autocomplete="off" placeholder="{{ _('Verification Code') }}" name="{{ confirm_form.code.name }}" class="form-control" style="width: 204px; display:inline-block;"/>
     </div>
     <div>
       <input type="submit" value="{% if reason == 'login' %}{{ _('Sign In') }}{% else %}{{ _('Confirm') }}{% endif %}" class="btn btn-primary" style="width:100px;" />

--- a/sampledb/frontend/templates/two_factor_authentication/set_up_totp.html
+++ b/sampledb/frontend/templates/two_factor_authentication/set_up_totp.html
@@ -10,7 +10,7 @@
     <p class="text-muted">{{ _('Please scan the following QR Code using an app such as Google Authenticator and then enter the generated verification code in the field below to complete the setup.') }}</p>
     <img src="{{ qrcode_url }}" alt="{{ _('TOTP Setup QR Code') }}" />
     <div class="form-group {% if setup_form.is_submitted() %}has-error{% endif %}">
-      <input type="text" placeholder="{{ _('Verification Code') }}" name="{{ setup_form.code.name }}" class="form-control" style="width: 204px; display:inline-block;"/>
+      <input type="text" autocomplete="off" placeholder="{{ _('Verification Code') }}" name="{{ setup_form.code.name }}" class="form-control" style="width: 204px; display:inline-block;"/>
     </div>
     <div>
       <input type="submit" value="{{ _('Set Up') }}" class="btn btn-primary" style="width:100px;" />


### PR DESCRIPTION
To my knowledge, the browser suggestion of old TOTP keys does not impose a security risk, but is not necessary and might be misleading.