### PR TITLE
Fixed the horrible performance loading the edit page with very large plotly objects

### DIFF
--- a/sampledb/frontend/templates/objects/forms/form_base.html
+++ b/sampledb/frontend/templates/objects/forms/form_base.html
@@ -45,6 +45,13 @@
       setupImageDragAndDrop(mde_field);
     });
 
+    $('textarea.plotly-chart-editor').each(function() {
+      var jsonStr = $( this ).text();
+      var jsonObj = JSON.parse(jsonStr);
+      var jsonPretty = JSON.stringify(jsonObj, null, '\t');
+      $( this ).text(jsonPretty);
+    });
+
     function updateSelectLanguage(selectpicker) {
       var enabled_languages = $(selectpicker).selectpicker('val');
       if (!Array.isArray(enabled_languages)) {

--- a/sampledb/frontend/templates/objects/forms/form_list_plotly_chart.html
+++ b/sampledb/frontend/templates/objects/forms/form_list_plotly_chart.html
@@ -1,3 +1,3 @@
 <div class="form-group{% if id_prefix+'_plotly' in errors %} has-error{% elif id_prefix+'_plotly' in form_data %} has-success{% endif %}" style="padding-right:0.75em; flex-grow: 1">
-    <textarea type="text" class="form-control plotly-chart-editor" name="{{ id_prefix }}_plotly" rows="5" placeholder="">{% if id_prefix+'_plotly' in form_data %}{{ form_data[id_prefix+'_plotly'] }}{% elif data is not none and "plotly" in data %}{{ data.plotly | to_json_no_extra_escapes(indent=2) }}{% endif %}</textarea>
+    <textarea type="text" class="form-control plotly-chart-editor" name="{{ id_prefix }}_plotly" rows="5" placeholder="">{% if id_prefix+'_plotly' in form_data %}{{ form_data[id_prefix+'_plotly'] }}{% elif data is not none and "plotly" in data %}{{ data.plotly | to_json_no_extra_escapes(indent=None) }}{% endif %}</textarea>
 </div>

--- a/sampledb/frontend/templates/objects/forms/form_plotly_chart.html
+++ b/sampledb/frontend/templates/objects/forms/form_plotly_chart.html
@@ -1,7 +1,7 @@
 <div class="form-group row{% if id_prefix+'_plotly' in errors %} has-error{% elif id_prefix+'_plotly' in form_data %} has-success{% endif %}" style="padding-right:0.75em">
-  <label class="control-label col-md-3 {% if schema.title and is_required %}required-label{% endif %}">{{ schema.title }}</label>
+  <label class="control-label col-md-3 {% if schema.title and is_required %}required-label{% endif %}">{{ schema.title | get_translated_text }}</label>
   <div class="col-md-9">
-    <textarea type="text" class="form-control plotly-chart-editor" name="{{ id_prefix }}_plotly" rows="5" placeholder="">{% if id_prefix+'_plotly' in form_data %}{{ form_data[id_prefix+'_plotly'] }}{% elif data is not none and "plotly" in data %}{{ data.plotly | to_json_no_extra_escapes(indent=2) }}{% endif %}</textarea>
+    <textarea type="text" class="form-control plotly-chart-editor" name="{{ id_prefix }}_plotly" rows="5" placeholder="">{% if id_prefix+'_plotly' in form_data %}{{ form_data[id_prefix+'_plotly'] }}{% elif data is not none and "plotly" in data %}{{ data.plotly | to_json_no_extra_escapes(indent=None) }}{% endif %}</textarea>
     {% if 'note' in schema %}<span class="help-block"><strong>{{ _('Note:') }}</strong> {{ schema['note'] | get_translated_text }}</span>{% endif %}
     </div>
 </div>

--- a/sampledb/frontend/templates/objects/forms/form_table_plotly_chart.html
+++ b/sampledb/frontend/templates/objects/forms/form_table_plotly_chart.html
@@ -1,3 +1,3 @@
 <div class="{% if id_prefix+'_plotly' in errors %}has-error{% elif id_prefix+'_plotly' in form_data %}has-success{% endif %}" style="padding-right:0.75em;">
-    <textarea type="text" rows="1" class="form-control plotly-chart-editor" name="{{ id_prefix }}_plotly" rows="5" placeholder="">{% if id_prefix+'_plotly' in form_data %}{{ form_data[id_prefix+'_plotly'] }}{% elif data is not none and "plotly" in data %}{{ data.plotly | to_json_no_extra_escapes(indent=2) }}{% endif %}</textarea>
+    <textarea type="text" rows="1" class="form-control plotly-chart-editor" name="{{ id_prefix }}_plotly" rows="5" placeholder="">{% if id_prefix+'_plotly' in form_data %}{{ form_data[id_prefix+'_plotly'] }}{% elif data is not none and "plotly" in data %}{{ data.plotly | to_json_no_extra_escapes(indent=None) }}{% endif %}</textarea>
 </div>

--- a/sampledb/frontend/templates/objects/view/plotly_chart.html
+++ b/sampledb/frontend/templates/objects/view/plotly_chart.html
@@ -2,7 +2,7 @@
 {% set plot_counter.value = plot_counter.value + 1 %}
 {% set plotly_chart_title = data.plotly | plotly_chart_get_title | striptags %}
 <div class="row" style="padding-right:0.75em">
-  <label class="col-md-3" style="text-align: right">{{ schema.title }}
+  <label class="col-md-3" style="text-align: right">{{ schema.title | get_translated_text }}
   {% if plotly_chart_title %}
     <a href="{{ url_for('.objects', q=search_query_attribute + ' == "' + plotly_chart_title + '"', advanced='on') }}" class="search-helper"><i class="fa fa-search" aria-hidden="true"></i></a>
   {% else %}


### PR DESCRIPTION
The introduced jinja filter 

"to_json_no_extra_escapes(indent=2)"

caused a horrendous performance while loading the edit page.
It dumps the plolty object as a string via json.dumps and when the indent parameter is used formats it nice and pretty. 
But the formatting in a textarea seems to be very slow when you have over 130k datapoints in your plotly data, causing the page to seemingly lag for several seconds. 

Now we just skip the indentation alltogether and initially load the textarea with a one-line JSON string and then afterwards format the JSON via javascript in the form_base js block.