### PR TITLE
Hide object_id

### DIFF
--- a/sampledb/frontend/objects.py
+++ b/sampledb/frontend/objects.py
@@ -1062,6 +1062,7 @@ def object(object_id):
             metadata_language = None
         return flask.render_template(
             'objects/view/base.html',
+            show_object_id=get_user_settings(flask_login.current_user.id)["SHOW_OBJECT_ID"],
             measurement_type_name=logic.action_type_translations.get_action_type_translation_for_action_type_in_language(
                 action_type_id=logic.actions.models.ActionType.MEASUREMENT,
                 language_id=logic.languages.get_user_language(flask_login.current_user).id,
@@ -1785,6 +1786,7 @@ def object_version(object_id, version_id):
         metadata_language = None
     return flask.render_template(
         'objects/view/base.html',
+        show_object_id=get_user_settings(flask_login.current_user.id)["SHOW_OBJECT_ID"],
         languages=languages,
         metadata_language=metadata_language,
         ENGLISH=english,

--- a/sampledb/frontend/objects.py
+++ b/sampledb/frontend/objects.py
@@ -456,6 +456,7 @@ def objects():
 
     return flask.render_template(
         'objects/objects.html',
+        show_object_id=get_user_settings(flask_login.current_user.id)["SHOW_OBJECT_ID"],
         objects=objects,
         display_properties=display_properties,
         display_property_titles=display_property_titles,

--- a/sampledb/frontend/objects.py
+++ b/sampledb/frontend/objects.py
@@ -285,13 +285,12 @@ def objects():
             else:
                 sorting_order_name = 'asc'
                 sorting_order = object_sorting.ascending
-        if get_user_settings(flask_login.current_user.id)["SHOW_OBJECT_ID"]:
-            if sorting_property_name is None:
+        if sorting_property_name is None:
+            if get_user_settings(flask_login.current_user.id)["SHOW_OBJECT_ID"]:
                 sorting_property_name = '_object_id'
             else:
                 name_only = False
-        else:
-            sorting_property_name = '_last_modification_date'
+                sorting_property_name = '_last_modification_date'
         if sorting_property_name == '_object_id':
             sorting_property = object_sorting.object_id()
         elif sorting_property_name == '_creation_date':

--- a/sampledb/frontend/objects.py
+++ b/sampledb/frontend/objects.py
@@ -285,11 +285,13 @@ def objects():
             else:
                 sorting_order_name = 'asc'
                 sorting_order = object_sorting.ascending
-
-        if sorting_property_name is None:
-            sorting_property_name = '_object_id'
+        if get_user_settings(flask_login.current_user.id)["SHOW_OBJECT_ID"]:
+            if sorting_property_name is None:
+                sorting_property_name = '_object_id'
+            else:
+                name_only = False
         else:
-            name_only = False
+            sorting_property_name = '_last_modification_date'
         if sorting_property_name == '_object_id':
             sorting_property = object_sorting.object_id()
         elif sorting_property_name == '_creation_date':

--- a/sampledb/frontend/templates/objects/objects.html
+++ b/sampledb/frontend/templates/objects/objects.html
@@ -108,7 +108,7 @@
   <table class="table" id="table-objects">
   <thead>
     <tr>
-      <th scope="col" rowspan="2">{{ _('ID') }} <span class="icons-sorting"><a href="{{ build_modified_url(sortby='_object_id', order='asc') }}"><i class="glyphicon glyphicon glyphicon-triangle-top {% if sorting_property == '_object_id' and sorting_order == 'asc' %}current_sorting_property{% endif %}" aria-hidden="true"></i></a><a href="{{ build_modified_url(sortby='_object_id', order='desc') }}"><i class="glyphicon glyphicon glyphicon-triangle-bottom {% if sorting_property == '_object_id' and sorting_order == 'desc' %}current_sorting_property{% endif %}" aria-hidden="true"></i></a></span></th>
+      {% if show_object_id %}<th scope="col" rowspan="2">{{ _('ID') }} <span class="icons-sorting"><a href="{{ build_modified_url(sortby='_object_id', order='asc') }}"><i class="glyphicon glyphicon glyphicon-triangle-top {% if sorting_property == '_object_id' and sorting_order == 'asc' %}current_sorting_property{% endif %}" aria-hidden="true"></i></a><a href="{{ build_modified_url(sortby='_object_id', order='desc') }}"><i class="glyphicon glyphicon glyphicon-triangle-bottom {% if sorting_property == '_object_id' and sorting_order == 'desc' %}current_sorting_property{% endif %}" aria-hidden="true"></i></a></span></th>{% endif %}
       <th scope="col" rowspan="2">{{ _('Name') }} <span class="icons-sorting"><a href="{{ build_modified_url(sortby='name', order='asc') }}"><i class="glyphicon glyphicon glyphicon-triangle-top {% if sorting_property == 'name' and sorting_order == 'asc' %}current_sorting_property{% endif %}" aria-hidden="true"></i></a><a href="{{ build_modified_url(sortby='name', order='desc') }}"><i class="glyphicon glyphicon glyphicon-triangle-bottom {% if sorting_property == 'name' and sorting_order == 'desc' %}current_sorting_property{% endif %}" aria-hidden="true"></i></a></span></th>
       <th scope="col" colspan="2">{{ _('Created') }}</th>
       <th scope="col" colspan="2">{{ _('Last modified') }}</th>
@@ -127,7 +127,7 @@
   <tbody>
   {% for object in objects %}
     <tr>
-      <th scope="row"><a href="{{ url_for('.object', object_id=object.object_id) }}">{{ object.object_id }}</a></th>
+      {% if show_object_id %}<th scope="row"><a href="{{ url_for('.object', object_id=object.object_id) }}">{{ object.object_id }}</a></th>{% endif %}
       <td><a href="{{ url_for('.object', object_id=object.object_id) }}">{{ object.data['name']['text'] | get_translated_text }}</a></td>
       <td>{{ object.created_at | babel_format_date }}</td>
       <td><a href="{{ url_for('.user_profile', user_id=object.created_by.id) }}">{{ object.created_by.name }}</a></td>

--- a/sampledb/frontend/templates/objects/view/base.html
+++ b/sampledb/frontend/templates/objects/view/base.html
@@ -27,7 +27,7 @@
   <script>
   window.plotly_charts = [];
   </script>
-  <h1>{{ action_type.translation.object_name }} #{{ object_id }}: {{ data.name.text | get_translated_text }}</h1>
+  <h1>{{ action_type.translation.object_name }}{% if show_object_id %} #{{ object_id }}{% endif %}: {{ data.name.text | get_translated_text }}</h1>
 
   <h2>{{ _('Information') }}</h2>
   <div class="row" style="padding-right:0.75em">

--- a/sampledb/frontend/templates/preferences.html
+++ b/sampledb/frontend/templates/preferences.html
@@ -123,7 +123,23 @@
            <tr>
              <td></td>
              <td></td>
-             <td class="text-right"><button type="button" class="btn btn-success" data-toggle="modal" data-target="#myModal"><i class="fa fa-plus" aria-hidden="true"></i></button></td>
+             <td class="text-right"><button typ<div class="form-group">
+      <label class="col-md-4 control-label" for="input-use-schema-editor-yes">
+        {{ _('Show object id') }}
+      </label>
+      <div class="radio col-md-4">
+        <label>
+          <input type="radio" name="input-show-object-id" id="input-show-object-id-yes" value="yes" {% if user_settings["SHOW_OBJECT_ID"] %}checked="checked"{% endif %}>
+          {{ _('Yes &mdash; Display ist (default)') }}
+        </label>
+      </div>
+      <div class="radio col-md-4">
+        <label>
+          <input type="radio" name="input-show-object-id" id="input-input-show-object-id-no" value="no" {% if not user_settings["SHOW_OBJECT_ID"] %}checked="checked"{% endif %}>
+          {{ _('No &mdash; Hide it') }}
+        </label>
+      </div>
+    </div>e="button" class="btn btn-success" data-toggle="modal" data-target="#myModal"><i class="fa fa-plus" aria-hidden="true"></i></button></td>
            </tr>
          </tfoot>
        </table>
@@ -536,6 +552,23 @@
         <label>
           <input type="radio" name="input-use-schema-editor" id="input-use-schema-editor-no" value="no" {% if not user_settings["USE_SCHEMA_EDITOR"] %}checked="checked"{% endif %}>
           {{ _('No &mdash; Edit schemas as JSON using a text editor (advanced)') }}
+        </label>
+      </div>
+    </div>
+    <div class="form-group">
+      <label class="col-md-4 control-label" for="input-use-schema-editor-yes">
+        {{ _('Show object id') }}
+      </label>
+      <div class="radio col-md-4">
+        <label>
+          <input type="radio" name="input-show-object-id" id="input-show-object-id-yes" value="yes" {% if user_settings["SHOW_OBJECT_ID"] %}checked="checked"{% endif %}>
+          {{ _('Yes &mdash; Display ist (default)') }}
+        </label>
+      </div>
+      <div class="radio col-md-4">
+        <label>
+          <input type="radio" name="input-show-object-id" id="input-input-show-object-id-no" value="no" {% if not user_settings["SHOW_OBJECT_ID"] %}checked="checked"{% endif %}>
+          {{ _('No &mdash; Hide it') }}
         </label>
       </div>
     </div>

--- a/sampledb/frontend/templates/preferences.html
+++ b/sampledb/frontend/templates/preferences.html
@@ -123,23 +123,7 @@
            <tr>
              <td></td>
              <td></td>
-             <td class="text-right"><button typ<div class="form-group">
-      <label class="col-md-4 control-label" for="input-use-schema-editor-yes">
-        {{ _('Show object id') }}
-      </label>
-      <div class="radio col-md-4">
-        <label>
-          <input type="radio" name="input-show-object-id" id="input-show-object-id-yes" value="yes" {% if user_settings["SHOW_OBJECT_ID"] %}checked="checked"{% endif %}>
-          {{ _('Yes &mdash; Display ist (default)') }}
-        </label>
-      </div>
-      <div class="radio col-md-4">
-        <label>
-          <input type="radio" name="input-show-object-id" id="input-input-show-object-id-no" value="no" {% if not user_settings["SHOW_OBJECT_ID"] %}checked="checked"{% endif %}>
-          {{ _('No &mdash; Hide it') }}
-        </label>
-      </div>
-    </div>e="button" class="btn btn-success" data-toggle="modal" data-target="#myModal"><i class="fa fa-plus" aria-hidden="true"></i></button></td>
+             <td class="text-right"><button type="button" class="btn btn-success" data-toggle="modal" data-target="#myModal"><i class="fa fa-plus" aria-hidden="true"></i></button></td>
            </tr>
          </tfoot>
        </table>

--- a/sampledb/frontend/templates/preferences.html
+++ b/sampledb/frontend/templates/preferences.html
@@ -546,7 +546,7 @@
       <div class="radio col-md-4">
         <label>
           <input type="radio" name="input-show-object-id" id="input-show-object-id-yes" value="yes" {% if user_settings["SHOW_OBJECT_ID"] %}checked="checked"{% endif %}>
-          {{ _('Yes &mdash; Display ist (default)') }}
+          {{ _('Yes &mdash; Display it (default)') }}
         </label>
       </div>
       <div class="radio col-md-4">

--- a/sampledb/frontend/users/preferences.py
+++ b/sampledb/frontend/users/preferences.py
@@ -539,6 +539,9 @@ def change_preferences(user, user_id):
             except ValueError:
                 pass
 
+        show_object_id = flask.request.form.get('input-show-object-id', 'yes') != 'no'
+        modified_settings['SHOW_OBJECT_ID'] = show_object_id
+
         if flask_login.current_user.is_admin:
             use_admin_permissions = flask.request.form.get('input-use-admin-permissions', 'yes') != 'no'
             modified_settings['USE_ADMIN_PERMISSIONS'] = use_admin_permissions

--- a/sampledb/logic/settings.py
+++ b/sampledb/logic/settings.py
@@ -24,6 +24,7 @@ from .users import get_user
 DEFAULT_SETTINGS = {
     "OBJECTS_PER_PAGE": 25,
     "USE_SCHEMA_EDITOR": True,
+    "SHOW_OBJECT_ID": True,
     "USE_ADMIN_PERMISSIONS": False,
     "SHOW_INVITATION_LOG": False,
     "INSTRUMENT_LOG_ORDER_ASCENDING": True,

--- a/sampledb/translations/de/LC_MESSAGES/extracted_messages.po
+++ b/sampledb/translations/de/LC_MESSAGES/extracted_messages.po
@@ -1484,6 +1484,15 @@ msgstr ""
 "Nein &mdash; Bearbeite Schemas als JSON mit einem Texteditor "
 "(fortgeschritten)"
 
+msgid "Show object id"
+msgstr "Zeige Object ID"
+
+msgid "Yes &mdash; Display ist (default)"
+msgstr "Ja &mdash; Anzeigen (default)"
+
+msgid "No &mdash; Hide it"
+msgstr "Nein &mdash; Verstecken"
+
 msgid "Language"
 msgstr "Sprache"
 

--- a/sampledb/translations/de/LC_MESSAGES/extracted_messages.po
+++ b/sampledb/translations/de/LC_MESSAGES/extracted_messages.po
@@ -1487,7 +1487,7 @@ msgstr ""
 msgid "Show object id"
 msgstr "Zeige Object ID"
 
-msgid "Yes &mdash; Display ist (default)"
+msgid "Yes &mdash; Display it (default)"
 msgstr "Ja &mdash; Anzeigen (default)"
 
 msgid "No &mdash; Hide it"


### PR DESCRIPTION
# Hiding the object_id
In special cases the name of an object includes a kind of id.
This id regularly isn't the same as the object_id of the given object.
To avoid irritations, showing the object_id has been made configurable.
![object](https://user-images.githubusercontent.com/76034861/137906923-ec2310ea-6c36-4798-9290-234a887eda43.png)
![objects](https://user-images.githubusercontent.com/76034861/137906935-9fec926e-632a-4511-8d7d-76c59e22ecba.png)
![preferences](https://user-images.githubusercontent.com/76034861/137907093-75927257-945e-413f-8207-16e79a2b7c67.png)
