### PR TITLE
use the official python image as base image + other changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ _*
 ldapaccount.py
 local.py
 docs/static/img/generated
+docker-compose.yml
 version.txt
 pgdata/
 files/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,18 +3,16 @@ FROM python:3.10-slim-bullseye
 LABEL maintainer="f.rhiem@fz-juelich.de"
 
 # Install required system packages
+# GCC is required to build python dependencies on ARM architectures
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y libpangocairo-1.0-0 gettext && \
+    apt-get install -y gcc libpangocairo-1.0-0 gettext && \
     rm -rf /var/lib/apt/lists/*
 
 # Switch to non-root user
 RUN useradd -ms /bin/bash sampledb
 USER sampledb
 WORKDIR /home/sampledb
-
-# This is where uploaded files will live (this folder will be mounted as a volume)
-RUN mkdir /home/sampledb/files
 
 # Install required Python packages
 COPY requirements.txt requirements.txt
@@ -36,8 +34,12 @@ ENV SAMPLEDB_PYBABEL_PATH=/home/sampledb/.local/bin/pybabel
 ARG SAMPLEDB_VERSION
 ENV SAMPLEDB_VERSION=$SAMPLEDB_VERSION
 
+# Copy the sdb helper script
+COPY ./sdb /usr/local/bin/sdb
+
 # The entrypoint script will set the file permissions for a mounted files directory and then start SampleDB
 ADD docker-entrypoint.sh docker-entrypoint.sh
+USER root
 ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["run"]
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you do not have Docker installed yet, please [install Docker](https://docs.do
 First, get the [docker-compose.yml](https://raw.githubusercontent.com/sciapp/sampledb/develop/docker-compose.yml) configuration file. You can git clone this repo or just get the file:
 
 ```bash
-curl https://raw.githubusercontent.com/sciapp/sampledb/develop/docker-compose.yml --output docker-compose.yml
+curl https://raw.githubusercontent.com/sciapp/sampledb/develop/docker-compose.yml.dist --output docker-compose.yml
 ```
 
 Then simply bring everything up with:

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -9,6 +9,9 @@ services:
     image: sciapp/sampledb:0.20.0
     restart: always
     container_name: sampledb
+    # Note: this config option works with docker-compose version >1.27
+    # If you are using an older docker-compose and cannot update to a newer version, you can use the short syntax instead
+    # See: https://docs.docker.com/compose/compose-file/#depends_on
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -1,5 +1,5 @@
 # sampledb docker-compose configuration file
-# use : "docker-compose up -d" to start containers
+# use: "docker-compose up -d" to start containers
 # https://github.com/sciapp/sampledb
 # Note: you will need to edit some values below to run it in production!
 version: '3'
@@ -9,6 +9,9 @@ services:
     image: sciapp/sampledb:0.20.0
     restart: always
     container_name: sampledb
+    depends_on:
+      db:
+        condition: service_healthy
     environment:
         - SAMPLEDB_CONTACT_EMAIL=sampledb@example.com
         - SAMPLEDB_MAIL_SERVER=mail.example.com
@@ -32,13 +35,18 @@ services:
     image: postgres:12
     restart: always
     container_name: sampledb-postgres
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     environment:
         - POSTGRES_PASSWORD=password
         - PGDATA=/var/lib/postgresql/data/pgdata
     volumes:
         # this is where you will keep the database persistently
         # host:container
-        - ./pgdata:/var/lib/postgresql/data/pgdata
+        - ./pgdata:/var/lib/postgresql/data
     networks:
       - sampledb-net
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-python -m sampledb "$0" "$@"
+chown sampledb:sampledb "${SAMPLEDB_FILE_STORAGE_PATH}"
+/usr/local/bin/sdb "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,3 +1,2 @@
 #!/bin/sh
-chown sampledb:sampledb "${SAMPLEDB_FILE_STORAGE_PATH}"
-exec su sampledb -c 'env/bin/python -m sampledb "$0" "$@"' -- "$@"
+python -m sampledb "$0" "$@"

--- a/docs/administrator_guide/administration_scripts.rst
+++ b/docs/administrator_guide/administration_scripts.rst
@@ -5,20 +5,28 @@ Administration Scripts
 
 Most administration features are available to administrators through the user interface. Some features which are rarely used or which would be useful for scripting purposes are available as scripts, so that they can be run using the SampleDB command line interface.
 
-If you are running SampleDB using Docker, you can execute these scripts using ``docker exec``. To get a list of all available scripts, you can run:
+If you are running SampleDB using Docker, you can execute these scripts using ``docker exec``. To make it easier, you can set an alias like so:
 
 .. code-block:: bash
 
-    docker exec sampledb env/bin/python -m sampledb help
+   alias sdb="docker exec -it sampledb sdb"
+
+Add this in your .bashrc or .zshrc depending if you use respectively bash or zsh as shell.
+
+To get a list of all available scripts, you can run:
+
+.. code-block:: bash
+
+    sdb help
 
 To then get a list of all actions, for example, you can run:
 
 .. code-block:: bash
 
-    docker exec sampledb env/bin/python -m sampledb list_actions
+    sdb list_actions
 
 To get information on how to run one of these scripts, you can run pass the `help` parameter to it:
 
 .. code-block:: bash
 
-    docker exec sampledb env/bin/python -m sampledb list_actions help
+    sdb list_actions help

--- a/sdb
+++ b/sdb
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# This script is a wrapper for sampledb app
+exec su sampledb -c 'python -m sampledb "$0" "$@"' -- "$@"


### PR DESCRIPTION
Hello Florian,

Here is my take at improving slightly the current docker image.


Using the official python image based on debian will make upgrading
python version easier. It also results in a smaller image:
Before: 1.11 Gb, now: 983 Mb

And more importantly it avoids having to install python and pip!

Other changes listed below:
* mv docker-compose.yml to docker-compose.yml.dist: allow user to have a
  custom docker-compose.yml that will be ignored by git (and might
  contain secrets!)
* don't keep pip cache around during installation of packages
* add the --user flag to pip install
* modify the curl command in README to get the new yml file
* add healthcheck on postgres image and make sampledb check for it
  before starting
* fix persistent path in db volume
* use COPY with chown flag to copy source code
* remove the chown command from the runtime script, create the dir in
  the image, which allows to:
* directly launch the entrypoint script as sampledb user