### PR TITLE
Reformat the help function in __main__.py

### DIFF
--- a/sampledb/__main__.py
+++ b/sampledb/__main__.py
@@ -2,7 +2,7 @@
 """
 Scripts for administrating SampleDB
 
-Usage: python -m sampledb <script> ...
+Usage: python -m sampledb <script> [options]
 """
 
 import sys
@@ -10,18 +10,10 @@ import sys
 from .scripts import script_documentation, script_functions
 
 
-available_scripts = list(script_functions.keys())
-available_scripts.sort()
-
-
 def help_and_exit(return_code):
-    print(
-        __doc__ + '\n'
-        'Available scripts:\n'
-        ' - ' + '\n - '.join(available_scripts) + '\n\n'
-        'To find out how more about a script, use:\n\n'
-        'python -m sampledb help <script>\n'
-    )
+    available_scripts = ' - ' + '\n - '.join(sorted(script_functions.keys()))
+    footer = '\n\nTo find out how more about a script, use:\n\npython -m sampledb help <script>'
+    print('{}\nAvailable scripts:\n{}{}'.format(__doc__, available_scripts, footer))
     exit(return_code)
 
 


### PR DESCRIPTION
Hello,

Pretty trivial change in the end, but I wanted to take a break from typescript/php, and because I want to familiarize myself with the codebase, my first entrypoint was `__main__.py` of course, and saw it could benefit from this small change.

Best,
~Nico


-----
* replace ... with [options] in doc comment
* move available_scripts variable in help_and_exit function scope
* use sorted instead of a two steps conversion/sort
* use formatted string
