### PR TITLE
Add accessibility link

### DIFF
--- a/docs/administrator_guide/configuration.rst
+++ b/docs/administrator_guide/configuration.rst
@@ -82,6 +82,8 @@ Customization
      - The URL to use for the imprint link
    * - SAMPLEDB_SERVICE_PRIVACY_POLICY
      - The URL to use for the privacy policy link
+   * - SAMPLEDB_SERVICE_ACCESSIBILITY
+     - The URL to use for the accessibility link
    * - SAMPLEDB_PDFEXPORT_LOGO_URL
      - A file, http or https URL for a PNG or JPEG logo to be included in object export PDF documents
    * - SAMPLEDB_PDFEXPORT_LOGO_ALIGNMENT

--- a/sampledb/__init__.py
+++ b/sampledb/__init__.py
@@ -110,6 +110,7 @@ def setup_jinja_environment(app):
         service_description=app.config['SERVICE_DESCRIPTION'],
         service_imprint=app.config['SERVICE_IMPRINT'],
         service_privacy_policy=app.config['SERVICE_PRIVACY_POLICY'],
+        service_accessibility=app.config['SERVICE_ACCESSIBILITY'],
         ldap_name=app.config['LDAP_NAME'],
         is_ldap_configured=is_ldap_configured,
         get_action_types=sampledb.logic.actions.get_action_types,

--- a/sampledb/config.py
+++ b/sampledb/config.py
@@ -424,6 +424,7 @@ SERVICE_DESCRIPTION = {
 }
 SERVICE_IMPRINT = None
 SERVICE_PRIVACY_POLICY = None
+SERVICE_ACCESSIBILITY = None
 SAMPLEDB_HELP_URL = 'https://scientific-it-systems.iffgit.fz-juelich.de/SampleDB/#documentation'
 
 # location for storing files

--- a/sampledb/frontend/templates/base.html
+++ b/sampledb/frontend/templates/base.html
@@ -281,7 +281,7 @@
 </div>
 <footer>
   <div class="container">
-    <p class="text-center text-muted">{{ service_name }} {{ _('is a service by the') }} <a href="https://pgi-jcns.fz-juelich.de/">PGI / JCNS Scientific IT-Systems</a> {{ _('team') }} &bullet; <a href="https://scientific-it-systems.iffgit.fz-juelich.de/SampleDB/user_guide/citations.html">{{ _('Citation Guide') }}</a>{% if service_imprint %} &bullet; <a href="{{ service_imprint }}">{{ _('Imprint') }}</a>{% endif %}{% if service_privacy_policy %} &bullet; <a href="{{ service_privacy_policy }}">{{ _('Privacy Policy') }}</a>{% endif %}</p>
+    <p class="text-center text-muted">{{ service_name }} {{ _('is a service by the') }} <a href="https://pgi-jcns.fz-juelich.de/">PGI / JCNS Scientific IT-Systems</a> {{ _('team') }} &bullet; <a href="https://scientific-it-systems.iffgit.fz-juelich.de/SampleDB/user_guide/citations.html">{{ _('Citation Guide') }}</a>{% if service_imprint %} &bullet; <a href="{{ service_imprint }}">{{ _('Imprint') }}</a>{% endif %}{% if service_privacy_policy %} &bullet; <a href="{{ service_privacy_policy }}">{{ _('Privacy Policy') }}</a>{% endif %}{% if service_accessibility %} &bullet; <a href="{{ service_accessibility }}">{{ _('Accessibility') }}</a>{% endif %}</p>
   </div>
 </footer>
  {% block scripts %}

--- a/sampledb/translations/de/LC_MESSAGES/extracted_messages.po
+++ b/sampledb/translations/de/LC_MESSAGES/extracted_messages.po
@@ -1289,6 +1289,9 @@ msgstr "Impressum"
 msgid "Privacy Policy"
 msgstr "Datenschutzerklärung"
 
+msgid "Accessibility"
+msgstr "Barrierefreiheit"
+
 msgid "Advanced Search…"
 msgstr "Erweiterte Suche…"
 


### PR DESCRIPTION
Since 2020, websites hosted by federal institutions are required to have an accessibility statement. I added the corresponding link to SampleDB (and I hope I didn't forget anything).