### PR TITLE
Improve docker image size by using multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM python:3.11-slim-bookworm as builder
 # Install required system packages
 # GCC is required to build python dependencies on ARM architectures
 # git is required to build python dependencies from git repositories
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y gcc git
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y gcc git
 
 # It's important to keep the same path in builder image and final image
 RUN useradd -ms /bin/bash sampledb
@@ -37,9 +38,10 @@ LABEL org.opencontainers.image.licenses=MIT
 # Install required system packages
 RUN apt-get update && \
     apt-get upgrade -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y libpangocairo-1.0-0 gettext
+    DEBIAN_FRONTEND=noninteractive apt-get install -y libpangocairo-1.0-0 gettext && \
+    rm -rf /var/lib/apt/lists/*
 
-
+# Switch to non-root user
 RUN useradd -ms /bin/bash sampledb
 USER sampledb
 WORKDIR /home/sampledb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,29 @@
+# Dockerfile for sampledb
+FROM python:3.11-slim-bookworm as builder
+
+# Install required system packages
+# GCC is required to build python dependencies on ARM architectures
+# git is required to build python dependencies from git repositories
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y gcc git
+
+# It's important to keep the same path in builder image and final image
+RUN useradd -ms /bin/bash sampledb
+USER sampledb
+WORKDIR /home/sampledb
+
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Set up virtual environment
+ENV VIRTUAL_ENV=/home/sampledb/venv
+RUN python3 -m venv $VIRTUAL_ENV
+RUN pip install --upgrade pip
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Install required Python packages
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Final image
 FROM python:3.11-slim-bookworm
 
 LABEL maintainer="f.rhiem@fz-juelich.de"
@@ -8,35 +34,27 @@ LABEL org.opencontainers.image.title="SampleDB"
 LABEL org.opencontainers.image.description="A web-based electronic lab notebook with a focus on sample and measurement metadata"
 LABEL org.opencontainers.image.licenses=MIT
 
-
 # Install required system packages
-# GCC is required to build python dependencies on ARM architectures
-# git is required to build python dependencies from git repositories
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y gcc libpangocairo-1.0-0 gettext git
+    DEBIAN_FRONTEND=noninteractive apt-get install -y libpangocairo-1.0-0 gettext
 
-# Switch to non-root user
+
 RUN useradd -ms /bin/bash sampledb
 USER sampledb
 WORKDIR /home/sampledb
 
+# Python specific config
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# Copy dependencies from builder image
+COPY --from=builder --chown=sampledb:sampledb /home/sampledb/venv /home/sampledb/venv
+
 # Set up virtual environment
 ENV VIRTUAL_ENV=/home/sampledb/venv
-RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-RUN  pip install --upgrade pip
-
-# Install required Python packages
-COPY requirements.txt requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
-
-# Clean up system packages that are no longer required
-USER root
-RUN apt-get remove -y gcc && \
-    apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/*
-USER sampledb
 
 # Copy sampledb source code
 COPY --chown=sampledb:sampledb sampledb sampledb


### PR DESCRIPTION
Currently the image is 1.3 GB, this change will bring it down to 972 MB, saving bandwidth and disk space to all.

The venv is built on an image and copied and used on another. This saves us from installing gcc and git in the final image.

Some env vars were added:

* DEBIAN_FRONTEND=noninteractive as is usual in apt scripts
* PYTHONDONTWRITEBYTECODE because it's useless in a container
* PYTHONUNBUFFERED don't try to buffer output
* PIP_DISABLE_PIP_VERSION_CHECK not sure if useful here but doesn't hurt



Note: I've tested it, it works fine as far as I can tell.