### PR TITLE
OIDC: PKCE + Access Tokens as API tokens

### DIFF
--- a/docs/administrator_guide/configuration.rst
+++ b/docs/administrator_guide/configuration.rst
@@ -95,6 +95,10 @@ OpenID Connect (OIDC)
      - If set, other login methods and invitations will be disabled. This does not affect API keys.
    * - SAMPLEDB_OIDC_CREATE_ACCOUNT
      - Which method should be used to create or link accounts. If ``auto_link`` (the default), new accounts will be automatically created and existing accounts linked via email. If ``deny_existing``, new accounts will be automatically created, but existing accounts must be manually configured to use OIDC. If ``no``, authentication methods must be manually added.
+   * - OIDC_ACCESS_TOKEN_AS_API_KEY
+     - If set, then OIDC Access Tokens may be used as API keys using ``Bearer Authentication``. Depending on the Access Token, validation may require an HTTP request to the OIDC provider, which can be enabled using ``OIDC_ACCESS_TOKEN_ALLOW_INTROSPECTION``.
+   * - OIDC_ACCESS_TOKEN_ALLOW_INTROSPECTION
+     - If set, then Access Tokens may be validated by making an HTTP request to the OIDC provider. Otherwise, they can only be validated if they are a JWT.
 
 If you use OIDC for user management, you can use these variables to configure how SampleDB should use your OIDC provider. See :ref:`OIDC<oidc>` for a detailed explanation.
 

--- a/docs/administrator_guide/oidc.rst
+++ b/docs/administrator_guide/oidc.rst
@@ -10,10 +10,12 @@ The client must be statically registered, while the configuration and keys must
 be dynamically discoverable.
 
 Only the Authorization Code Flow with ``client_secret_basic`` authentication
-is supported. The OIDC provider should support the ``nonce`` parameter to
-allow for the detection of replay attacks. To increase compatibility with some
-providers, the use of the parameter can be disabled using a configuration
-variable. This is not recommended.
+is supported. Proof Key for Code Exchange (PKCE) is used if the OIDC provider
+signals support for the ``S256`` method. The provider should support the
+``nonce`` parameter to allow for the detection of replay attacks. To increase
+compatibility with some providers, the use of the parameter can be disabled
+using a configuration variable. If a provider supports neither PKCE with
+method ``S256``, nor ``nonce``, using it is not recommended.
 
 RP-Initiated Logout will be used if the provider indicates support.
 Back-Channel and Front-Channel Logout are not currently implemented.

--- a/docs/administrator_guide/oidc.rst
+++ b/docs/administrator_guide/oidc.rst
@@ -6,8 +6,10 @@ OpenID Connect (OIDC)
 If you use OIDC for user management, you can configure SampleDB to connect to
 a single OIDC provider using the
 :ref:`OIDC Configuration Environment Variables <oidc_configuration>`.
-The client must be statically registered, while the configuration and keys must
-be dynamically discoverable.
+
+The client must be statically registered, while the configuration and keys
+must be dynamically discoverable. The ``name``, ``email`` and
+``email_verified`` claims are required.
 
 Only the Authorization Code Flow with ``client_secret_basic`` authentication
 is supported. Proof Key for Code Exchange (PKCE) is used if the OIDC provider
@@ -63,5 +65,5 @@ Based on the provided ID Token and variable
 user as active and not hidden, and will not change whether they are readonly
 or an admin.
 
-Note: Setting the ``is_not_active`` role will prevent the user from logging
-in.
+.. note::
+  Setting the ``is_not_active`` role will prevent the user from logging in.

--- a/docs/administrator_guide/oidc.rst
+++ b/docs/administrator_guide/oidc.rst
@@ -67,3 +67,30 @@ or an admin.
 
 .. note::
   Setting the ``is_not_active`` role will prevent the user from logging in.
+
+Access Tokens as API keys
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+SampleDB can be configured to allow OIDC Access Tokens as API tokens using the
+``Bearer Authentication`` of the :ref:`HTTP API<http_api>`. These tokens work
+like regular user-bound API tokens and are validated for every request. The
+lifetime of the Access Token is set by the provider.
+
+OIDC Access Tokens are validated by making an HTTP request to the
+Introspection Endpoint of the provider, which then returns either the relevant
+user details or an error. Alternatively, if the provider encodes its Access
+Tokens as JSON Web Tokens (JWT), then validation may omit the introspection
+request and rely on the cryptographic signature of the token.
+
+.. note::
+  SampleDB will first try to validate other types of API tokens,
+  then try to validate the token as a JWT, and only if it is not a JWT and
+  introspection is enabled, will SampleDB make the introspection request.
+  Meaning, if introspection is enabled, every API request with an invalid
+  API token will result in a request to the OIDC provider.
+
+.. note::
+  API requests will not create user accounts or update user
+  profiles, meaning the user making the API request must already have their
+  account linked to the provider. However, if OIDC roles are used, they will
+  be updated. Or, if they are missing or invalid, fail the login.

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,7 @@ qrcode==8.0
 requests==2.32.3
 scipy==1.15.1
 setuptools==75.8.0
-simple_openid_connect @ git+https://github.com/timhallmann/py_simple_openid_connect.git@9125e1dc9da9a0233a5f5b504a7416006afc5e70
+simple_openid_connect @ git+https://github.com/fsinfuhh/py_simple_openid_connect.git@9135e68896bb2b3d2aecc80114fc34a36b19a457
 six==1.17.0
 soupsieve==2.6
 SQLAlchemy==2.0.38

--- a/sampledb/config.py
+++ b/sampledb/config.py
@@ -140,6 +140,8 @@ def parse_configuration_values() -> None:
         'ENABLE_FEDERATED_LOGIN_CREATE_NEW_USER',
         'OIDC_ONLY',
         'OIDC_DISABLE_NONCE',
+        'OIDC_ACCESS_TOKEN_AS_API_KEY',
+        'OIDC_ACCESS_TOKEN_ALLOW_INTROSPECTION',
     ]:
         value = globals().get(config_name)
         if isinstance(value, str):
@@ -739,6 +741,8 @@ OIDC_DISABLE_NONCE = False
 OIDC_ROLES = None
 OIDC_ONLY = False
 OIDC_CREATE_ACCOUNT = 'auto_link'
+OIDC_ACCESS_TOKEN_AS_API_KEY = False
+OIDC_ACCESS_TOKEN_ALLOW_INTROSPECTION = False
 
 # email settings
 MAIL_SERVER = None

--- a/sampledb/frontend/users/authentication.py
+++ b/sampledb/frontend/users/authentication.py
@@ -291,7 +291,7 @@ def oidc_start() -> FlaskResponseT:
         flask.flash(_('OIDC is disabled.'), 'error')
         return flask.redirect(flask.url_for('.index'))
 
-    if flask_login.current_user.is_authenticated:
+    if flask_login.current_user.is_authenticated and flask_login.login_fresh():
         return _redirect_to_next_url()
 
     url, token = oidc.start_authentication(
@@ -307,7 +307,7 @@ def oidc_callback() -> FlaskResponseT:
         flask.flash(_('OIDC is disabled.'), 'error')
         return flask.redirect(flask.url_for('.index'))
 
-    if flask_login.current_user.is_authenticated:
+    if flask_login.current_user.is_authenticated and flask_login.login_fresh():
         return _redirect_to_next_url()
 
     try:

--- a/sampledb/logic/authentication.py
+++ b/sampledb/logic/authentication.py
@@ -633,6 +633,24 @@ def login_via_api_refresh_token(api_refresh_token: str) -> typing.Optional[logic
     return None
 
 
+def login_via_oidc_access_token(access_token: str) -> typing.Optional[logic.users.User]:
+    """
+    Authenticate a user using an OIDC Access Token, if OIDC is configured and
+    Access Tokens may be used as API keys.
+
+    :param access_token: the access token to use for authentication
+    :return: the user, or None
+    """
+    if not flask.current_app.config['OIDC_ACCESS_TOKEN_AS_API_KEY']:
+        return None
+    try:
+        authentication_method, user = logic.oidc.validate_access_token(access_token)
+    except:
+        return None
+    api_log.create_log_entry(authentication_method.id, HTTPMethod.from_name(flask.request.method), flask.request.path)
+    return user
+
+
 def add_authentication_method(user_id: int, login: str, password: str, authentication_type: AuthenticationType) -> bool:
     """
     Add an authentication method for a user.


### PR DESCRIPTION
PKCE: Some OIDC-compatible providers implement PKCE but do not fully implement OIDC. In such cases, PKCE provides similar guarantees to OIDC nonces, so I have added support for PKCE.

Access Tokens as API tokens: Other applications using the same OIDC provider as the SampleDB instance may use their Access Token as an API token for the SampleDB. Disabled by default.