### PR TITLE
Accept placeholder_data via URL query param

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Currently in development.
 - Added setting for disabling object assignments for individual locations
 - Added setting for default notification types
 - Added info pages
+- Added query placeholder
 - Refactored related objects tree to improve performance
 - Improved support of array index placeholders and object references in search queries
 - Allow searching for multiple conditions inside a subtree of an object's properties

--- a/docs/user_guide/schemas.rst
+++ b/docs/user_guide/schemas.rst
@@ -1667,3 +1667,51 @@ As ``bool`` inputs do not support a ``null`` value you might use ``false`` to un
       },
       "required": ["name"]
     }
+
+Query Placeholder
+-----------------
+
+When creating new objects through the user interface, query placeholders can
+automatically populate predefined values. This allows another application,
+script, or bookmark to specify known values, while the user manually enters
+the remaining ones.
+
+For example:
+
+::
+
+  /objects/new?action_id=1&properties.name=via_query_placeholder
+
+  # or:
+
+  /objects/new?action_id=1
+  &properties.name=test
+  &properties.count=100
+  &properties.size=10nm
+  &properties.created=2025-01-01 10:20:30
+  &properties.boolfield=false
+  &properties.sample=1
+  &properties.tags=a,b
+  &properties.multilayer.0.repetitions=1
+
+Limitations:
+
+- Quantities must use one of the units specified in the schema of the field.
+  E.g., if a schema expects either ``µm`` or ``nm``, then it's not possible to
+  use ``um``.
+- The unit of unitless quantities must be set as ``1`` within the schema.
+- Values in Arrays, Objects and Conditional Properties can only be populated
+  if the specified field would have been rendered by default. E.g., it's not
+  possible to populate a field in an array if the array defaults to zero
+  items.
+- Only the following types are supported:
+
+  - quantity
+  - text
+  - bool
+  - datetime
+  - tags
+  - user
+  - object_reference
+  - sample
+  - measurement

--- a/sampledb/translations/de/LC_MESSAGES/extracted_messages.po
+++ b/sampledb/translations/de/LC_MESSAGES/extracted_messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  1\n"
 "Report-Msgid-Bugs-To: f.rhiem@fz-juelich.de\n"
-"POT-Creation-Date: 2025-05-08 13:14+0200\n"
+"POT-Creation-Date: 2025-05-14 18:13+0200\n"
 "PO-Revision-Date: 2022-04-18 17:38+0200\n"
 "Last-Translator: Florian Rhiem <f.rhiem@fz-juelich.de>\n"
 "Language: de\n"
@@ -1607,6 +1607,26 @@ msgstr "Das ausgewählte Objekt kann nicht in dieser Aktion verwendet werden."
 
 msgid "The selected objects cannot be used in this action."
 msgstr "Die ausgewählten Objekte können nicht in dieser Aktion verwendet werden."
+
+#, python-format
+msgid "The path \"%(path)s\" is not valid for the schema of this action."
+msgstr "Der Pfad \"%(path)s\" ist für das Schema dieser Aktion nicht gültig."
+
+#, python-format
+msgid ""
+"The unit of \"%(path)s=%(value)s\" does not match the unit(s) of the "
+"schema: %(units)s"
+msgstr ""
+"Die Einheit von \"%(path)s=%(value)s\" stimmt nicht mit den Einheiten des"
+" Schemas überein: %(units)s"
+
+#, python-format
+msgid ""
+"The value of \"%(path)s=%(value)s\" is not valid for this schema: "
+"%(schema)s"
+msgstr ""
+"Der Wert von \"%(path)s=%(value)s\" ist nicht gültig für dieses Schema: "
+"%(schema)s"
 
 msgid "API Log"
 msgstr "API Log"


### PR DESCRIPTION
It's quite useful for us to generate links that set a few properties and let the user enter the remaining data.

While I like the ergonomics from a user perspective, the implementation feels a bit more complicated than it should be. Am I missing any functions that could aid in the parsing of the arguments?

If there are any reasons to change the `property` key or if keys like `properties.name=test` would be preferable, I'd be happy to change that.

E.g.:

```
/objects/new?action_id=1
&property=name=test
&property=count=100
&property=size=10nm
&property=created=2025-01-01T10:20:30
&property=boolfield=false
&property=sample=1
&property=tags=a,b
&property=multilayer.0.repetitions=1
```

Note: Some of these properties are not valid for action 1 in the demo, so these would need to be removed to test this feature.