### PR TITLE
Enable CORS for API endpoints

### DIFF
--- a/requirements.raw.txt
+++ b/requirements.raw.txt
@@ -6,6 +6,7 @@ email-validator
 fido2
 Flask
 Flask-Babel
+Flask-Cors
 Flask-HTTPAuth
 Flask-Login
 Flask-Mail

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ email_validator==2.2.0
 fido2==1.2.0
 Flask==3.1.0
 flask-babel==4.0.0
+Flask-Cors==6.0.0
 Flask-HTTPAuth==4.8.0
 Flask-Login==0.6.3
 Flask-Mail==0.10.0

--- a/sampledb/api/server/__init__.py
+++ b/sampledb/api/server/__init__.py
@@ -4,6 +4,7 @@ RESTful API for SampleDB
 """
 
 from flask import Blueprint
+from flask_cors import CORS
 from .objects import Object, Objects, ObjectVersion, ObjectVersions, RelatedObjects
 from .actions import Action, Actions
 from .action_types import ActionType, ActionTypes
@@ -20,6 +21,7 @@ from .groups import Group, Groups
 from .projects import Project, Projects
 
 api = Blueprint('api', __name__)
+CORS(api)
 api.add_url_rule('/api/v1/objects/', endpoint='objects', view_func=Objects.as_view('objects'))
 api.add_url_rule('/api/v1/objects/<int:object_id>', endpoint='object', view_func=Object.as_view('object'))
 api.add_url_rule('/api/v1/objects/<int:object_id>/versions/', endpoint='object_versions', view_func=ObjectVersions.as_view('object_versions'))


### PR DESCRIPTION
Cross-Origin Resource Sharing (CORS) permits browsers to relax their same-origin policies, so that other websites may use the HTTP API.