### PR TITLE
Add bulk permission management and copy functionality via API

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,8 @@ Currently in development.
 - Fixed array tables
 - Fixed style variants
 - Fixed editing of language settings
+- Added OIDC session expiration and Back-Channel Logout
+- Added HTTP API endpoints for bulk object permission management
 
 
 Version 0.32

--- a/docs/developer_guide/api.rst
+++ b/docs/developer_guide/api.rst
@@ -537,6 +537,163 @@ Setting the permissions for anonymous users
     :statuscode 404: the object does not exist
 
 
+Reading all permissions of an object
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. http:get:: /api/v1/objects/(int:object_id)/permissions/
+
+    Get all permission mappings.
+
+    **Example request**:
+
+    .. sourcecode:: http
+
+        GET /api/v1/objects/1/permissions/ HTTP/1.1
+        Host: iffsamples.fz-juelich.de
+        Accept: application/json
+        Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=
+
+    **Example response**:
+
+    .. sourcecode:: http
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        {
+            "users": {
+                1: "grant"
+            },
+            "groups": {
+                2: "read"
+            },
+            "projects": {
+                2: "read"
+            },
+            "authenticated_users" : "none",
+            "anonymous_users": "none"
+        }
+
+    :<json object users: user_ids and their associated permission for this object
+    :<json object groups: group_ids and their associated permission for this object
+    :<json object projects: project_ids and their associated permission for this object
+    :<json object authenticated_users: permission all authenticated users have to this object
+    :<json object anonymous_users: permission all users have to this object
+    :statuscode 200: no error
+    :statuscode 403: the user does not have READ permissions for this object
+    :statuscode 404: the object does not exist
+
+
+Setting all permissions of an object
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. http:put:: /api/v1/objects/(int:object_id)/permissions/
+
+    Set and/or change multiple permissions to the given object.
+    Does keep non-colliding permissions that are already set and will return all currently applied permissions for this object.
+
+    **Example request**:
+
+    .. sourcecode:: http
+
+        PUT /api/v1/objects/1/permissions/ HTTP/1.1
+        Host: iffsamples.fz-juelich.de
+        Content-Type: application/json
+        Accept: application/json
+        Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=
+
+        {
+            "users": {
+                1: "grant"
+            },
+            "groups": {
+                2: "read"
+            },
+            "projects": {
+                2: "write"
+            },
+            "authenticated_users" : "none",
+            "anonymous_users": "none"
+        }
+        
+    :<json object users: user_ids and their associated permission for this object (optional)
+    :<json object groups: group_ids and their associated permission for this object (optional)
+    :<json object projects: project_ids and their associated permission for this object (optional)
+    :<json object authenticated_users: permission all authenticated users have to this object (optional)
+    :<json object anonymous_users: permission all users have to this object (optional)
+
+    **Example response**:
+
+    .. sourcecode:: http
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        {
+            "users": {
+                1: "grant"
+            },
+            "groups": {
+                2: "read"
+            },
+            "projects": {
+                2: "write"
+            },
+            "authenticated_users" : "none",
+            "anonymous_users": "none"
+        }
+
+    :statuscode 200: no error
+    :statuscode 400: invalid data (should be "read", "write", "grant" or "none")
+    :statuscode 403: the user does not have GRANT permissions for this object
+    :statuscode 404: the object or user does not exist
+
+
+Copying all permissions from one object to another
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. http:post:: /api/v1/objects/permissions/copy/
+
+    Sets the permissions of the target object exactly to the permissions of the source object.
+    Request object can either be a list of objects or one object providing a source- and a target-object_id.
+
+    **Example request**:
+
+    .. sourcecode:: http
+
+        PUT /api/v1/objects/permissions/copy/ HTTP/1.1
+        Host: iffsamples.fz-juelich.de
+        Content-Type: application/json
+        Accept: application/json
+        Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=
+
+        [
+            {
+                "source_object_id": 1,
+                "target_object_id": 3,
+            },
+            {
+                "source_object_id": 4,
+                "target_object_id": 2,
+            }
+        ]
+
+    :<json number source_object_id: the object_id from which the permissions should be copied
+    :<json number target_object_id: the object_id where the copied permissions should be applied to
+
+    **Example response**:
+
+    .. sourcecode:: http
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+    :statuscode 200: no error
+    :statuscode 400: invalid data (must be either list of json objects or json object with properties 'source' and 'target')
+    :statuscode 403: user does not have GRANT permissions on 'target' object or READ permission on 'source' object
+    :statuscode 404: 'target' or 'source' object does not exist
+
+
 Reading all users' permissions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ authors = [
     { name="Nils Holle", email="nils.holle@uni-muenster.de" },
     { name="Moritz Hannemann", email="m.hannemann@fz-juelich.de" },
     { name="Moritz Velde", email="m.velde@fz-juelich.de" },
+    { name="Florian Bauer", email="fl.bauer@fz-juelich.de" },
     { name="Dorothea Henkel" },
     { name="Du Kim Nguyen" },
     { name="Frederik Peters" },

--- a/sampledb/api/server/__init__.py
+++ b/sampledb/api/server/__init__.py
@@ -15,7 +15,7 @@ from .instruments import Instrument, Instruments
 from .instrument_log import InstrumentLogEntry, InstrumentLogEntries, InstrumentLogEntryVersions, InstrumentLogEntryVersion, InstrumentLogEntryFileAttachment, InstrumentLogEntryFileAttachments, InstrumentLogEntryObjectAttachment, InstrumentLogEntryObjectAttachments, InstrumentLogCategory, InstrumentLogCategories
 from .locations import Location, Locations, ObjectLocationAssignment, ObjectLocationAssignments, LocationType, LocationTypes
 from .object_log import ObjectLogEntries
-from .object_permissions import UsersObjectPermissions, UserObjectPermissions, GroupsObjectPermissions, GroupObjectPermissions, ProjectsObjectPermissions, ProjectObjectPermissions, PublicObjectPermissions, AuthenticatedUserObjectPermissions, AnonymousUserObjectPermissions
+from .object_permissions import ObjectPermissions, UsersObjectPermissions, UserObjectPermissions, GroupsObjectPermissions, GroupObjectPermissions, ProjectsObjectPermissions, ProjectObjectPermissions, PublicObjectPermissions, AuthenticatedUserObjectPermissions, AnonymousUserObjectPermissions, CopyObjectsPermissions
 from .users import CurrentUser, User, Users
 from .groups import Group, Groups
 from .projects import Project, Projects
@@ -50,10 +50,12 @@ api.add_url_rule('/api/v1/locations/', endpoint='locations', view_func=Locations
 api.add_url_rule('/api/v1/locations/<int:location_id>', endpoint='location', view_func=Location.as_view('location'))
 api.add_url_rule('/api/v1/location_types/', endpoint='location_types', view_func=LocationTypes.as_view('location_types'))
 api.add_url_rule('/api/v1/location_types/<int(signed=True):location_type_id>', endpoint='location_type', view_func=LocationType.as_view('location_type'))
+api.add_url_rule('/api/v1/objects/permissions/copy/', endpoint='copy_objects_permissions', view_func=CopyObjectsPermissions.as_view('copy_objects_permissions'))
 api.add_url_rule('/api/v1/objects/<int:object_id>/files/', endpoint='object_files', view_func=ObjectFiles.as_view('object_files'))
 api.add_url_rule('/api/v1/objects/<int:object_id>/files/<int:file_id>', endpoint='object_file', view_func=ObjectFile.as_view('object_file'))
 api.add_url_rule('/api/v1/objects/<int:object_id>/locations/', endpoint='object_location_assignments', view_func=ObjectLocationAssignments.as_view('object_location_assignments'))
 api.add_url_rule('/api/v1/objects/<int:object_id>/locations/<int:object_location_assignment_index>', endpoint='object_location_assignment', view_func=ObjectLocationAssignment.as_view('object_location_assignment'))
+api.add_url_rule('/api/v1/objects/<int:object_id>/permissions/', endpoint='object_permissions', view_func=ObjectPermissions.as_view('object_permissions'))
 api.add_url_rule('/api/v1/objects/<int:object_id>/permissions/users/', endpoint='users_object_permissions', view_func=UsersObjectPermissions.as_view('users_object_permissions'))
 api.add_url_rule('/api/v1/objects/<int:object_id>/permissions/users/<int:user_id>', endpoint='user_object_permissions', view_func=UserObjectPermissions.as_view('user_object_permissions'))
 api.add_url_rule('/api/v1/objects/<int:object_id>/permissions/groups/', endpoint='groups_object_permissions', view_func=GroupsObjectPermissions.as_view('groups_object_permissions'))

--- a/sampledb/api/server/object_permissions.py
+++ b/sampledb/api/server/object_permissions.py
@@ -3,14 +3,298 @@
 RESTful API for SampleDB
 """
 
+import functools
+import typing
 import flask
 
-from .authentication import object_permissions_required
+from .authentication import object_permissions_required, multi_auth
 from ..utils import Resource, ResponseData
-from ...logic import users, groups, projects, errors, object_permissions, background_tasks
+from ...logic import users, groups, projects, errors, object_permissions, background_tasks, objects
 from ...models import Permissions
 
 __author__ = 'Florian Rhiem <f.rhiem@fz-juelich.de>'
+
+
+def all_object_permissions_dict_to_json(permissions: object_permissions.AllObjectPermissionsDict) -> typing.Dict[str, typing.Any]:
+    return {
+        "users": {
+            user_id: permission.name.lower() for user_id, permission in permissions["users"].items()
+        },
+        "groups": {
+            group_id: permission.name.lower() for group_id, permission in permissions["groups"].items()
+        },
+        "projects": {
+            project_id: permission.name.lower() for project_id, permission in permissions["projects"].items()
+        },
+        "authenticated_users": permissions["authenticated"].name.lower(),
+        "anonymous_users": permissions["anonymous"].name.lower(),
+    }
+
+
+class ObjectPermissions(Resource):
+    @object_permissions_required(Permissions.READ)
+    def get(self, object_id: int) -> ResponseData:
+        try:
+            permissions = object_permissions.get_all_object_permissions(object_id=object_id)
+        except errors.ObjectDoesNotExistError:
+            return {
+                "message": f"object {object_id} does not exist"
+            }, 404
+        return all_object_permissions_dict_to_json(
+            permissions
+        ), 200
+
+    @object_permissions_required(Permissions.GRANT)
+    def put(self, object_id: int) -> ResponseData:
+        request_json = flask.request.get_json(force=True)
+        update_functions = []
+        if type(request_json) is not dict:
+            return {
+                "message": "JSON dict body required"
+            }, 400
+
+        # User-Permissions
+        if (user_perms_json := request_json.get("users")) is not None:
+            if type(user_perms_json) is not dict:
+                return {
+                    "message": "'users' is required to be a JSON object"
+                }, 400
+            for user_id, permission in user_perms_json.items():
+                try:
+                    users.check_user_exists(int(user_id))
+                except (errors.UserDoesNotExistError, ValueError):
+                    return {
+                        "message": f"user {user_id} does not exist"
+                    }, 404
+                if type(permission) is not str:
+                    return {
+                        "message": "JSON string for permission required"
+                    }, 400
+                try:
+                    user_permissions = Permissions.from_name(permission)
+                except ValueError:
+                    return {
+                        "message": f"Permissions name for user {user_id} required"
+                    }, 400
+
+                update_functions.append(
+                    functools.partial(
+                        object_permissions.set_user_object_permissions,
+                        object_id,
+                        user_id,
+                        user_permissions,
+                    )
+                )
+
+        # Group-Permissions
+        if (group_perms_json := request_json.get("groups")) is not None:
+            if type(group_perms_json) is not dict:
+                return {
+                    "message": "'groups' is required to be a JSON object"
+                }, 400
+            for group_id, permission in group_perms_json.items():
+                try:
+                    groups.get_group(int(group_id))
+                except (errors.GroupDoesNotExistError, ValueError):
+                    return {
+                        "message": f"group {group_id} does not exist"
+                    }, 404
+                if type(permission) is not str:
+                    return {
+                        "message": "JSON string for permission required"
+                    }, 400
+                try:
+                    group_permissions = Permissions.from_name(permission)
+                except ValueError:
+                    return {
+                        "message": f"Permissions name for group {group_id} required"
+                    }, 400
+
+                update_functions.append(
+                    functools.partial(
+                        object_permissions.set_group_object_permissions,
+                        object_id,
+                        group_id,
+                        group_permissions,
+                    )
+                )
+
+        # Project-Permissions
+        if (project_perms_json := request_json.get("projects")) is not None:
+            if type(project_perms_json) is not dict:
+                return {
+                    "message": "'projects' is required to be a JSON object"
+                }, 400
+            for project_id, permission in project_perms_json.items():
+                try:
+                    projects.get_project(int(project_id))
+                except (errors.ProjectDoesNotExistError, ValueError):
+                    return {
+                        "message": f"project {project_id} does not exist"
+                    }, 404
+                if type(permission) is not str:
+                    return {
+                        "message": "JSON string for permission required"
+                    }, 400
+                try:
+                    project_permissions = Permissions.from_name(permission)
+                except ValueError:
+                    return {
+                        "message": f"Permissions name for project {project_id} required"
+                    }, 400
+
+                update_functions.append(
+                    functools.partial(
+                        object_permissions.set_project_object_permissions,
+                        object_id,
+                        project_id,
+                        project_permissions,
+                    )
+                )
+
+        # Authenticated
+        if (authenticated_perms_json := request_json.get("authenticated_users")) is not None:
+            if type(authenticated_perms_json) is not str:
+                return {
+                    "message": "JSON string for permission required"
+                }, 400
+            try:
+                authenticated_permissions = Permissions.from_name(authenticated_perms_json)
+            except ValueError:
+                return {
+                    "message": "Permissions name for authenticated users required"
+                }, 400
+
+            if authenticated_permissions not in {Permissions.NONE, Permissions.READ}:
+                return {
+                    "message": 'expected "none" or "read"'
+                }, 400
+
+            update_functions.append(
+                functools.partial(
+                    object_permissions.set_object_permissions_for_all_users,
+                    object_id,
+                    authenticated_permissions,
+                )
+            )
+
+        # Anonymous
+        if (public_perms_json := request_json.get("anonymous_users")) is not None:
+            if public_perms_json is not None and not flask.current_app.config['ENABLE_ANONYMOUS_USERS']:
+                return {
+                    "message": "anonymous users are disabled"
+                }, 400
+            if type(public_perms_json) is not str:
+                return {
+                    "message": "JSON string for permission required"
+                }, 400
+            try:
+                public_permissions = Permissions.from_name(public_perms_json)
+            except ValueError:
+                return {
+                    "message": "Permissions name for anonymous users required"
+                }, 400
+
+            if public_permissions not in {Permissions.NONE, Permissions.READ}:
+                return {
+                    "message": 'expected "none" or "read"'
+                }, 400
+
+            update_functions.append(
+                functools.partial(
+                    object_permissions.set_object_permissions_for_anonymous_users,
+                    object_id,
+                    public_permissions,
+                )
+            )
+
+        for item in update_functions:
+            item()
+
+        return all_object_permissions_dict_to_json(
+            object_permissions.get_all_object_permissions(object_id=object_id)
+        ), 200
+
+
+class CopyObjectsPermissions(Resource):
+    @multi_auth.login_required
+    def post(self) -> ResponseData:
+        user_id = flask.g.user.id
+        user = users.get_user(user_id=user_id)
+        if user.is_readonly:
+            return {
+                "message": "No permission to copy object's permissions"
+            }, 403
+        request_json = flask.request.get_json(force=True)
+        if type(request_json) is dict:
+            request_json = [request_json]
+        elif type(request_json) is not list:
+            return {
+                "message": "JSON list or dict body required"
+            }, 400
+        try:
+            for item in request_json:
+                if type(item) is not dict:
+                    return {
+                        "message": "JSON list or dict body required"
+                    }, 400
+                source_object_id = item.get("source_object_id", None)
+                target_object_id = item.get("target_object_id", None)
+                if type(source_object_id) is not int:
+                    return {
+                        "message": "source_object_id for JSON object required"
+                    }, 400
+                if type(target_object_id) is not int:
+                    return {
+                        "message": "target_object_id for JSON object required"
+                    }, 400
+                # Validating all incoming object ids before changing any permission
+                for object_id in [source_object_id, target_object_id]:
+                    try:
+                        objects.check_object_exists(object_id)
+                    except errors.ObjectDoesNotExistError:
+                        return {
+                            "message": f"object {object_id} does not exist"
+                        }, 404
+
+                # Assure highest permission for source object is atleast READ
+                # to view object's permission
+                if max(
+                    object_permissions.get_object_permissions_for_all_users(source_object_id),
+                    object_permissions.get_user_object_permissions(
+                        object_id=source_object_id,
+                        user_id=user_id,
+                    )
+                ) < Permissions.READ:
+                    return {
+                        "message": f"missing object permission for source object {source_object_id}"
+                    }, 403
+
+                # Assure highest permission for target object is atleast GRANT
+                # to allow permission-manipulation
+                if object_permissions.get_user_object_permissions(
+                    object_id=target_object_id,
+                    user_id=user_id,
+                ) < Permissions.GRANT:
+                    return {
+                        "message": f"missing object permission for target object {target_object_id}"
+                    }, 403
+
+        except ValueError:
+            return {
+                "message": "body parameters 'source' and 'target' are required to be object IDs"
+            }, 400
+        except KeyError:
+            return {
+                "message": "JSON dict body required 'source' and 'target' key"
+            }, 400
+
+        for item in request_json:
+            object_permissions.copy_permissions(
+                source_object_id=item["source_object_id"],
+                target_object_id=item["target_object_id"],
+            )
+        return "", 200
 
 
 class UserObjectPermissions(Resource):

--- a/sampledb/logic/object_permissions.py
+++ b/sampledb/logic/object_permissions.py
@@ -97,6 +97,45 @@ def set_project_object_permissions(object_id: int, project_id: int, permissions:
     object_permissions.set_permissions_for_project(resource_id=object_id, project_id=project_id, permissions=permissions)
 
 
+class AllObjectPermissionsDict(typing.TypedDict):
+    users: typing.Dict[int, Permissions]
+    groups: typing.Dict[int, Permissions]
+    projects: typing.Dict[int, Permissions]
+    authenticated: Permissions
+    anonymous: Permissions
+
+
+def get_all_object_permissions(object_id: int) -> AllObjectPermissionsDict:
+    objects.check_object_exists(object_id=object_id)
+    user_permissions = get_object_permissions_for_users(
+        object_id=object_id,
+        include_instrument_responsible_users=False,
+        include_groups=False,
+        include_projects=False,
+        include_admin_permissions=False,
+    )
+    basic_group_permissions = get_object_permissions_for_groups(
+        object_id=object_id,
+        include_projects=False,
+    )
+    project_permissions = get_object_permissions_for_projects(
+        object_id=object_id,
+    )
+    all_user_permissions = get_object_permissions_for_all_users(
+        object_id=object_id
+    )
+    anonymous_user_permissions = get_object_permissions_for_anonymous_users(
+        object_id=object_id
+    )
+    return {
+        "users": user_permissions,
+        "groups": basic_group_permissions,
+        "projects": project_permissions,
+        "authenticated": all_user_permissions,
+        "anonymous": anonymous_user_permissions
+    }
+
+
 def _get_object_responsible_user_ids(object_id: int) -> typing.List[int]:
     object = objects.get_object(object_id)
     if object.action_id is None:

--- a/tests/api/server/test_object_permissions.py
+++ b/tests/api/server/test_object_permissions.py
@@ -487,3 +487,219 @@ def test_set_anonymous_user_object_permissions(flask_server, auth, object_id):
     assert r.json() == {
         "message": "anonymous users are disabled"
     }
+
+
+def test_get_all_object_permissions(flask_server, auth, user, other_user, object_id):
+    group_id = sampledb.logic.groups.create_group("Example Group", "", other_user.id).id
+    sampledb.logic.object_permissions.set_group_object_permissions(object_id, group_id, sampledb.models.Permissions.WRITE)
+    project_id = sampledb.logic.projects.create_project("Example Project", "", other_user.id).id
+    sampledb.logic.object_permissions.set_project_object_permissions(object_id, project_id, sampledb.models.Permissions.GRANT)
+    sampledb.logic.projects.add_group_to_project(project_id, group_id, sampledb.models.Permissions.GRANT)
+    sampledb.logic.object_permissions.set_user_object_permissions(object_id=object_id, user_id=user.id, permissions=sampledb.models.Permissions.READ)
+    sampledb.logic.object_permissions.set_user_object_permissions(object_id=object_id, user_id=other_user.id, permissions=sampledb.models.Permissions.READ)
+
+    r_all = requests.get(flask_server.base_url + 'api/v1/objects/{}/permissions'.format(object_id), auth=auth)
+    r_users = requests.get(flask_server.base_url + 'api/v1/objects/{}/permissions/users'.format(object_id), auth=auth)
+    r_groups = requests.get(flask_server.base_url + 'api/v1/objects/{}/permissions/groups'.format(object_id), auth=auth)
+    r_projects = requests.get(flask_server.base_url + 'api/v1/objects/{}/permissions/projects'.format(object_id), auth=auth)
+    r_authenticated = requests.get(flask_server.base_url + 'api/v1/objects/{}/permissions/authenticated_users'.format(object_id), auth=auth)
+    r_anonymous = requests.get(flask_server.base_url + 'api/v1/objects/{}/permissions/anonymous_users'.format(object_id), auth=auth)
+
+    assert r_all.status_code == 200
+    assert r_all.json()["users"] == r_users.json()
+    assert r_all.json()["groups"] == r_groups.json()
+    assert r_all.json()["projects"] == r_projects.json()
+    assert r_all.json()["authenticated_users"] == r_authenticated.json()
+    assert r_all.json()["anonymous_users"] == (r_anonymous.json() if r_anonymous.ok else 'none')
+
+    r_all = requests.get(flask_server.base_url + 'api/v1/objects/{}/permissions'.format(object_id+1), auth=auth)
+    assert r_all.status_code == 404
+
+
+def test_set_object_permissions(flask_server, auth, user, other_user, object_id):
+    # Apply perms for 2 out of 3 (users, groups, projects)
+    # Stick with the first permission;
+    # Remove (change) perm for second;
+    # Add perm for third (user, group, project)
+    sampledb.logic.object_permissions.set_user_object_permissions(
+        object_id,
+        user.id,
+        sampledb.models.Permissions.GRANT
+    )
+    sampledb.logic.object_permissions.set_user_object_permissions(
+        object_id,
+        other_user.id,
+        sampledb.models.Permissions.GRANT
+    )
+    with flask_server.app.app_context():
+        third_user = sampledb.models.User(name="Third User", email="third_user@example.com", type=sampledb.models.UserType.PERSON)
+        sampledb.db.session.add(third_user)
+        sampledb.db.session.commit()
+        assert third_user.id is not None
+    group_ids = [sampledb.logic.groups.create_group(f"Example Group{i}", "", other_user.id).id for i in range(3)]
+    [
+        sampledb.logic.object_permissions.set_group_object_permissions(
+            object_id,
+            group_id,
+            sampledb.models.Permissions.WRITE,
+        )
+        for group_id in group_ids
+    ]
+    project_ids = [sampledb.logic.projects.create_project(f"Example Project{i}", "", other_user.id).id for i in range(3)]
+    [
+        sampledb.logic.object_permissions.set_project_object_permissions(
+            object_id,
+            project_id,
+            sampledb.models.Permissions.GRANT,
+        )
+        for project_id in project_ids
+    ]
+
+    sampledb.logic.object_permissions.set_object_permissions_for_all_users(object_id,sampledb.models.Permissions.READ)
+    flask_server.app.config['ENABLE_ANONYMOUS_USERS'] = True
+    sampledb.logic.object_permissions.set_object_permissions_for_anonymous_users(object_id,sampledb.models.Permissions.READ)
+    request_json = {
+        "users": {
+            other_user.id: "none",
+            third_user.id: "read",
+        },
+        "groups": {
+            group_ids[1]: 'none',
+            group_ids[2]: 'read',
+        },
+        "projects": {
+            project_ids[1]: 'none',
+            project_ids[2]: 'read',
+        },
+    }
+    r = requests.put(flask_server.base_url + 'api/v1/objects/{}/permissions'.format(object_id), json=request_json, auth=auth)
+    assert r.status_code == 200
+
+    assert all([
+        r.json()["users"][str(user.id)] == 'grant',
+        r.json()["users"].get(str(other_user.id)) == None,
+        r.json()["users"][str(third_user.id)] == "read"
+    ])
+    assert all([
+        r.json()["groups"][str(group_ids[0])] == 'write',
+        r.json()["groups"].get(str(group_ids[1])) == None,
+        r.json()["groups"][str(group_ids[2])] == 'read',
+    ])
+    assert all([
+        r.json()["projects"][str(project_ids[0])] == 'grant',
+        r.json()["projects"].get(str(project_ids[1])) == None,
+        r.json()["projects"][str(project_ids[2])] == 'read',
+    ])
+    assert r.json()["authenticated_users"] == 'read'
+    assert r.json()["anonymous_users"] == 'read'
+
+    request_json = {
+        'authenticated_users': 'none',
+        'anonymous_users': 'none',
+    }
+    r = requests.put(flask_server.base_url + 'api/v1/objects/{}/permissions'.format(object_id), json=request_json, auth=auth)
+    assert r.status_code == 200
+    assert r.json()["authenticated_users"] == 'none'
+    assert r.json()["anonymous_users"] == 'none'
+
+    r = requests.put(flask_server.base_url + 'api/v1/objects/{}/permissions'.format(object_id+1), json=request_json, auth=auth)
+    assert r.status_code == 404
+
+    flask_server.app.config['ENABLE_ANONYMOUS_USERS'] = False
+    request_json = {
+        'anonymous_users': 'read',
+    }
+    r = requests.put(flask_server.base_url + 'api/v1/objects/{}/permissions'.format(object_id), json=request_json, auth=auth)
+    assert r.status_code == 400
+    assert r.json() == {
+        "message": "anonymous users are disabled"
+    }
+
+
+def test_copy_object_permissions(flask_server, auth, user, other_user, object_id, action):
+    data = {
+        'name': {
+            '_type': 'text',
+            'text': 'Example'
+        }
+    }
+    sampledb.logic.object_permissions.set_user_object_permissions(object_id, other_user.id, sampledb.models.Permissions.GRANT)
+    group_id = sampledb.logic.groups.create_group("Example Group", "", other_user.id).id
+    sampledb.logic.object_permissions.set_group_object_permissions(object_id, group_id, sampledb.models.Permissions.WRITE)
+    project_id = sampledb.logic.projects.create_project("Example Project", "", other_user.id).id
+    sampledb.logic.object_permissions.set_project_object_permissions(object_id, project_id, sampledb.models.Permissions.WRITE)
+    other_object = sampledb.logic.objects.create_object(action_id=action.id, data=data, user_id=user.id)
+    other_object_id = other_object.object_id
+    request_json = {
+        "source_object_id": object_id,
+        "target_object_id": other_object_id,
+    }
+    r = requests.post(flask_server.base_url + '/api/v1/objects/permissions/copy/', json=request_json, auth=auth)
+    assert r.status_code == 200
+    r = requests.get(flask_server.base_url + 'api/v1/objects/{}/permissions'.format(other_object_id), json=request_json, auth=auth)
+    assert r.status_code == 200
+    perms_source_object = sampledb.api.server.object_permissions.all_object_permissions_dict_to_json(sampledb.logic.object_permissions.get_all_object_permissions(object_id))
+    perms_source_object["users"] = {str(k): v for k,v in perms_source_object["users"].items()} if perms_source_object.get("users") else None
+    perms_source_object["groups"] = {str(k): v for k,v in perms_source_object["groups"].items()} if perms_source_object.get("groups") else None
+    perms_source_object["projects"] = {str(k): v for k,v in perms_source_object["projects"].items()} if perms_source_object.get("projects") else None
+
+    for key in perms_source_object.keys():
+        assert r.json()[key] == perms_source_object[key]
+
+    # Multiple copy requests at once
+    b_object = sampledb.logic.objects.create_object(action_id=action.id, data=data, user_id=user.id)
+    b_object_id = b_object.object_id
+    c_object = sampledb.logic.objects.create_object(action_id=action.id, data=data, user_id=user.id)
+    c_object_id = c_object.object_id
+
+    # Make sure c_object and b_object do not have the same permissions as object
+    perms_source = requests.get(flask_server.base_url + 'api/v1/objects/{}/permissions'.format(object_id), json=request_json, auth=auth).json()
+    perms_b_obj = requests.get(flask_server.base_url + 'api/v1/objects/{}/permissions'.format(b_object_id), json=request_json, auth=auth).json()
+    perms_c_obj = requests.get(flask_server.base_url + 'api/v1/objects/{}/permissions'.format(c_object_id), json=request_json, auth=auth).json()
+    assert not all([perms_source.get(key, None) == perms_b_obj.get(key, None) for key in perms_source.keys()]) # Fails if object and b_object have same permissions
+    assert not all([perms_source.get(key, None) == perms_c_obj.get(key, None) for key in perms_source.keys()]) # Failes if object and c_object have same permissions
+
+    request_json = [
+        {
+        "source_object_id": object_id,
+        "target_object_id": b_object_id,
+        },
+        {
+        "source_object_id": object_id,
+        "target_object_id": c_object_id,
+        },
+    ]
+    r = requests.post(flask_server.base_url + '/api/v1/objects/permissions/copy/', json=request_json, auth=auth)
+    assert r.status_code == 200
+    perms_source = requests.get(flask_server.base_url + 'api/v1/objects/{}/permissions'.format(object_id), json=request_json, auth=auth).json()
+    perms_b_obj = requests.get(flask_server.base_url + 'api/v1/objects/{}/permissions'.format(b_object_id), json=request_json, auth=auth).json()
+    perms_c_obj = requests.get(flask_server.base_url + 'api/v1/objects/{}/permissions'.format(c_object_id), json=request_json, auth=auth).json()
+    for key in perms_source.keys():
+        assert perms_source[key] == perms_b_obj[key]
+        assert perms_source[key] == perms_c_obj[key]
+
+    request_json = {
+        "source_object_id": object_id,
+        "target_object_id": other_object_id,
+    }
+
+    # Not enough permission to view source object's permissions
+    sampledb.logic.object_permissions.set_user_object_permissions(object_id, user.id, sampledb.models.Permissions.NONE)
+    r = requests.post(flask_server.base_url + '/api/v1/objects/permissions/copy/', json=request_json, auth=auth)
+    assert r.status_code == 403
+
+    # Not enough permissions to perform a grant action on target object
+    sampledb.logic.object_permissions.set_user_object_permissions(object_id, user.id, sampledb.models.Permissions.READ)
+    sampledb.logic.object_permissions.set_user_object_permissions(other_object_id, user.id, sampledb.models.Permissions.READ)
+    r = requests.post(flask_server.base_url + '/api/v1/objects/permissions/copy/', json=request_json, auth=auth)
+    assert r.status_code == 403
+
+    # Not existing object
+    last_object = sampledb.logic.objects.create_object(action_id=action.id, data=data, user_id=user.id)
+    last_object_id = last_object.object_id
+    request_json = {
+        "source_object_id": object_id,
+        "target_object_id": last_object_id+1,
+    }
+    r = requests.post(flask_server.base_url + '/api/v1/objects/permissions/copy/', json=request_json, auth=auth)
+    assert r.status_code == 404

--- a/tests/frontend/test_status_codes.py
+++ b/tests/frontend/test_status_codes.py
@@ -332,6 +332,7 @@ def test_status_codes(flask_server, user, driver):
         f'api/v1/objects/{object_id}/files/{file_id}': 200,
         f'api/v1/objects/{object_id}/locations/': 200,
         f'api/v1/objects/{object_id}/locations/{object_location_assignment_index}': 200,
+        f'api/v1/objects/{object_id}/permissions/': 200,
         f'api/v1/objects/{object_id}/permissions/anonymous_users': 400,  # 400 because anonymous users are disabled
         f'api/v1/objects/{object_id}/permissions/authenticated_users': 200,
         f'api/v1/objects/{object_id}/permissions/groups/': 200,
@@ -350,6 +351,7 @@ def test_status_codes(flask_server, user, driver):
         f'api/v1/objects/{other_object_id}/files/{file_id}': 404,
         f'api/v1/objects/{other_object_id}/locations/': 200,
         f'api/v1/objects/{other_object_id}/locations/{object_location_assignment_index}': 404,
+        f'api/v1/objects/{other_object_id}/permissions/': 200,
         f'api/v1/objects/{other_object_id}/permissions/anonymous_users': 400,  # 400 because anonymous users are disabled
         f'api/v1/objects/{other_object_id}/permissions/authenticated_users': 200,
         f'api/v1/objects/{other_object_id}/permissions/groups/': 200,


### PR DESCRIPTION
In our hosted instance, we are creating objects with a bot account for specific users because we can't upload them directly from the user's account. Nevertheless we'd like to use the same permissions from the sample on the process we just performed on it. While there's currently just the option to read and set each permission type (users, group, projects, ...) individually, we'd like to reduce API-requests by having an endpoint to get all permissions that are given to an objects at once.

This is why I've added the endpoint /objects/<object_id>/permissions/.
On GET the endpoint will return a dictionary of all "permission-types":
```
{
    "users": {
        1: "grant"
    },
    "basic_groups": {
        2: "read"
    },
    "projects": {
        2: "read"
    },
    "authenticated" : "none",
    "anonymous": "none"
}
```
Using PUT on the same endpoint with a dictionary of at least one key from above will perform the given permissions to the object. (This does not remove all existing permissions of the given object and set the new ones. It will only change or add the given permissions)

We also like to add the endpoint /objects/permissions/copy/. This endpoint uses the already implemented function "object_permissions.copy_permissions()" and is able to receive multiple "source"-"target" object pairs, where the target's permissions get overwritten by the source object's permissions.
Performing a POST-request with json-data like:
```
[
    {
        "source": 1,
        "target": 2
    },
    {
        "source": 4,
        "target": 3
    }
]
```
... will for example overwrite the object-permissions from object {2} with those from object {1}.

You can either perform the request with a list of json-objects or just with one json-object like:
```    
{
    "source": 1,
    "target": 2
}
```