### PR TITLE
Fix setting the action_id in multiselect_actions

### DIFF
--- a/sampledb/frontend/templates/objects/objects.html
+++ b/sampledb/frontend/templates/objects/objects.html
@@ -697,7 +697,7 @@
         </div>
       {% else %}
         <span id="multiselect-submit-tooltip" style="display: inline-block;" tabindex="0" data-toggle="tooltip" title="{{ _("You have to select at least one object.") }}">
-          <button type="submit" class="btn btn-primary" id="multiselect-submit" disabled data-action-type-id="{{ use_in_action_type.id }}">{{ _('Use in %(action_type_name)s', action_type_name=use_in_action_type.name|get_translated_text) }}</button>
+          <button type="submit" class="btn btn-primary" id="multiselect-submit" disabled data-action-type-id="{{ use_in_action_type.id }}" name="{{ use_in_action_form.action_type_id.name }}" value="{{ use_in_action_type.id }}">{{ _('Use in %(action_type_name)s', action_type_name=use_in_action_type.name|get_translated_text) }}</button>
         </span>
       {% endif %}
     </div>


### PR DESCRIPTION
If the user has no favorites set for that action type, the "Use in action_type" button does not set a filter for the action type when opening the actions list.