### PR TITLE
Use timestamptz columns for Login model

### DIFF
--- a/sampledb/models/authentication.py
+++ b/sampledb/models/authentication.py
@@ -67,8 +67,8 @@ class Login(Model):
     id: Mapped[int] = db.Column(db.Integer, primary_key=True)
     user_id: Mapped[int] = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
     type: Mapped[AuthenticationType] = db.Column(db.Enum(AuthenticationType), nullable=False)
-    created_at: Mapped[datetime] = db.Column(db.DateTime, nullable=False, default=functions.now())
-    expires_at: Mapped[datetime] = db.Column(db.DateTime, nullable=False)
+    created_at: Mapped[datetime] = db.Column(db.TIMESTAMP(timezone=True), nullable=False, default=functions.now())
+    expires_at: Mapped[datetime] = db.Column(db.TIMESTAMP(timezone=True), nullable=False)
     data: Mapped[typing.Dict[str, typing.Any]] = db.Column(postgresql.JSONB, nullable=False)
     user: Mapped['User'] = relationship('User')
 

--- a/sampledb/models/migrations/logins_use_timestamptz.py
+++ b/sampledb/models/migrations/logins_use_timestamptz.py
@@ -1,0 +1,20 @@
+# coding: utf-8
+"""
+In the logins table, replace columns of type TIMESTAMP WITHOUT TIME ZONE with
+columns of type TIMESTAMP WITH TIME ZONE, using UTC for the conversion.
+"""
+
+import flask_sqlalchemy
+
+from .utils import timestamp_add_timezone_utc_migration
+
+
+def run(db: flask_sqlalchemy.SQLAlchemy) -> bool:
+    migrations_ran = [
+        timestamp_add_timezone_utc_migration(table_name, column_name)
+        for table_name, column_name in [
+            ('logins', 'created_at'),
+            ('logins', 'expires_at'),
+        ]
+    ]
+    return any(migrations_ran)

--- a/sampledb/models/migrations/utils.py
+++ b/sampledb/models/migrations/utils.py
@@ -253,6 +253,7 @@ def get_migrations() -> typing.List[typing.Tuple[int, str, typing.Callable[[typi
         "topics_split_show_in_navbar",
         'webhook_type_add_object_permissions',
         "object_data_to_html_cache_entries_add_show_object_title",
+        "logins_use_timestamptz",
     ]
 
     migrations = []


### PR DESCRIPTION
I'm not sure how I've missed the timestamp without time zone columns before, but we do need them with time zones.

The migration might not be strictly necessary, the Login model was introduced only after the last release.